### PR TITLE
Allow missing TokenOwnerRecord for Withdraw and ChangeOwner instructions #23

### DIFF
--- a/addin-vesting/program/src/error.rs
+++ b/addin-vesting/program/src/error.rs
@@ -59,6 +59,9 @@ pub enum VestingError {
 
     #[error("InvalidPercentage")]
     InvalidPercentage,
+
+    #[error("Invalid TokenOwnerRecord")]
+    InvalidTokenOwnerRecord,
 }
 
 impl From<VestingError> for ProgramError {

--- a/addin-vesting/program/src/lib.rs
+++ b/addin-vesting/program/src/lib.rs
@@ -6,5 +6,6 @@ pub mod instruction;
 pub mod state;
 pub mod voter_weight;
 pub mod max_voter_weight;
+pub mod token_owner_record;
 
 pub mod processor;

--- a/addin-vesting/program/src/processor.rs
+++ b/addin-vesting/program/src/processor.rs
@@ -37,6 +37,9 @@ use crate::{
         create_max_voter_weight_record,
         get_max_voter_weight_record_data_checked,
     },
+    token_owner_record::{
+        get_token_owner_record_data_if_exists,
+    },
 };
 
 pub struct Processor {}
@@ -275,7 +278,7 @@ impl Processor {
             let realm_data = get_realm_data(governance_account.key, realm_account)?;
             realm_data.assert_is_valid_governing_token_mint(&vesting_record.mint)?;
 
-            let owner_record_data = get_token_owner_record_data_for_seeds(
+            let owner_record_optional_data = get_token_owner_record_data_if_exists(
                 governance_account.key,
                 owner_record_account,
                 &get_token_owner_record_address_seeds(
@@ -284,7 +287,9 @@ impl Processor {
                     vesting_owner_account.key,
                 ),
             )?;
-            owner_record_data.assert_can_withdraw_governing_tokens()?;
+            if let Some(owner_record_data) = owner_record_optional_data {
+                owner_record_data.assert_can_withdraw_governing_tokens()?;
+            }
 
             let mut voter_weight_record = get_voter_weight_record_data_checked(
                     program_id,
@@ -363,7 +368,7 @@ impl Processor {
             let realm_data = get_realm_data(governance_account.key, realm_account)?;
             realm_data.assert_is_valid_governing_token_mint(&vesting_record.mint)?;
 
-            let owner_record_data = get_token_owner_record_data_for_seeds(
+            let owner_record_optional_data = get_token_owner_record_data_if_exists(
                 governance_account.key,
                 owner_record_account,
                 &get_token_owner_record_address_seeds(
@@ -372,7 +377,9 @@ impl Processor {
                     vesting_owner_account.key,
                 ),
             )?;
-            owner_record_data.assert_can_withdraw_governing_tokens()?;
+            if let Some(owner_record_data) = owner_record_optional_data {
+                owner_record_data.assert_can_withdraw_governing_tokens()?;
+            }
 
             let mut voter_weight_record = get_voter_weight_record_data_checked(
                     program_id,

--- a/addin-vesting/program/src/token_owner_record.rs
+++ b/addin-vesting/program/src/token_owner_record.rs
@@ -1,0 +1,41 @@
+use crate::error::VestingError;
+use solana_program::{
+    account_info::AccountInfo,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+    system_program,
+};
+
+use spl_governance::state::{
+    token_owner_record::{
+        TokenOwnerRecordV2,
+        get_token_owner_record_data_for_seeds,
+    },
+};
+
+pub fn get_token_owner_record_data_if_exists(
+    program_id: &Pubkey,
+    token_owner_record_info: &AccountInfo,
+    token_owner_record_seeds: &[&[u8]],
+) -> Result<Option<TokenOwnerRecordV2>, ProgramError> {
+    let (token_owner_record_address, _) = 
+        Pubkey::find_program_address(token_owner_record_seeds, program_id);
+
+    if token_owner_record_address != *token_owner_record_info.key {
+        return Err(VestingError::InvalidTokenOwnerRecord.into());
+    }
+
+    if token_owner_record_info.data_is_empty() {
+        if *token_owner_record_info.owner != system_program::id() {
+            return Err(VestingError::InvalidTokenOwnerRecord.into());
+        }
+
+        Ok(None)
+    } else {
+        Ok(Some(get_token_owner_record_data_for_seeds(
+            program_id,
+            token_owner_record_info,
+            token_owner_record_seeds)?
+        ))
+    }
+}


### PR DESCRIPTION
- Introduce `get_token_owner_record_data_if_exists` functions - return None if TokenOwnerRecord doesn't exists
- fix function test to check this situation